### PR TITLE
Fix/queueapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,7 +2080,7 @@ checksum = "3b9b39299b249ad65f3b7e96443bad61c02ca5cd3589f46cb6d610a0fd6c0d6a"
 
 [[package]]
 name = "sscan"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 # Crate Information
 name = "sscan"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["ctx400"]
 description = "A scriptable file/process/network scanner"
 repository = "https://github.com/ctx400/sscan"

--- a/OPEN_SOURCE_LICENSES.html
+++ b/OPEN_SOURCE_LICENSES.html
@@ -7917,7 +7917,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/ctx400/sscan ">sscan 0.11.0</a></li>
+                    <li><a href=" https://github.com/ctx400/sscan ">sscan 0.11.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright 2025 ctx400 (https://github.com/ctx400)
 

--- a/src/userscript_api/queue_api.rs
+++ b/src/userscript_api/queue_api.rs
@@ -124,7 +124,7 @@ async fn queue_dequeue(
             Ok((name, path, content)) => {
                 let content = mlua::String::wrap(content);
                 Ok((name, path, content))
-            },
+            }
             Err(error) => Err(error.into_lua_err()),
         }
     } else {

--- a/src/userscript_api/queue_api.rs
+++ b/src/userscript_api/queue_api.rs
@@ -118,10 +118,13 @@ async fn queue_dequeue(
     _: Lua,
     this: UserDataRef<QueueApi>,
     (): (),
-) -> mlua::Result<(String, Option<PathBuf>, Vec<u8>)> {
+) -> mlua::Result<(String, Option<PathBuf>, impl mlua::IntoLua)> {
     if let Some(queue) = this.0.upgrade() {
         match queue.ask(Dequeue).await {
-            Ok(dqi) => Ok(dqi),
+            Ok((name, path, content)) => {
+                let content = mlua::String::wrap(content);
+                Ok((name, path, content))
+            },
             Err(error) => Err(error.into_lua_err()),
         }
     } else {


### PR DESCRIPTION
Closes #25.

Fixes an issue where the `queue:dequeue()` Lua API was returning a `table` instead of a `string`.

By chance, the fix also *substantially* improved performance, at least on linux.